### PR TITLE
Add jcan library dependency

### DIFF
--- a/onTruckPlugin/pom.xml
+++ b/onTruckPlugin/pom.xml
@@ -3,6 +3,19 @@
 	<artifactId>onTruck</artifactId>
 	<groupId>com.github.onTruck</groupId>
 	<version>0.0.1</version>
+	<repositories>
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
+	</repositories>
+	<dependencies>
+		<dependency>
+			<groupId>com.github.hulthe</groupId>
+			<artifactId>moped-canlib</artifactId>
+			<version>0.0.3</version>
+		</dependency>
+	</dependencies>
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
Acceptance Criteria:
  - The plugin compiles
  - Dependencies can be imported