### PR TITLE
Add group members and information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## DAT255 - Group Smiley
 
-Course-related documentation can be found in the `/documents`-branch (e.g. Reflection Report)
+The `documents` branch contains all non-code specific documentation & course-related documentation (e.g. Social contract and Reflection report)
 
 `/doc` folder contains code-specific documentation (e.g. TCP-protocol)
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
-## DAT255
-Course-related documentation can be found in the `/documents`-branch
+## DAT255 - Group Smiley
+
+Course-related documentation can be found in the `/documents`-branch (e.g. Reflection Report)
+
+`/doc` folder contains code-specific documentation (e.g. TCP-protocol)
+
+`/onTruckConnector` folder contains the Android app project for connecting remotely to the MOPED
+- Further information can be found in the folder-specific README
+
+`/onTruckPlugin` folder contains the files which act as a server to the controller application
+- Further information can be found in the folder-specific README
+
+`/python-scripts` folder contains (edited) python scripts (e.g. `run.py`)
+
+
+### Group members:
+
+- Carlsson, Oscar (oscca)
+- Hulthe, Joakim (hulthe)
+- Josefsson, Emil (emiljos)
+- Landgren, Lovisa (lovlan)
+- Larborn, Sofia (soflarb)
+- Levén, William (levenw)
+- Levholm, Anton (levholm)
+- Mårdh, Agnes (agnesma)
+- Rudnick, Kevin (rudnick)
+- Segerstedt, John (sejohn)
+- Wikström, Karl (karlwik)
+- Åberg, Fredrik (abergf)


### PR DESCRIPTION
- Project disposition should exist in the Readme (according to slides)
- Adds clarity to the repo
- Group members added to make it easier for teachers

Acceptance criteria:
- Group thinks changes are good